### PR TITLE
fix schema validation error due to format change

### DIFF
--- a/R/annotations.R
+++ b/R/annotations.R
@@ -279,19 +279,20 @@ TYPES_MAPPING <- list(
 
 # verifies whether data schema has the right type and throws an informative
 # exception if it doesn't
+
 schema_compare <- function(x) {
   types = malevnc:::clio_fetch(.url_clio_schema())
-  types = sapply(types$properties, function(x) x$type[1])
+  types = sapply(types$properties, function(x) x$type[[1]])
   col_types  = sapply(x, class, simplify = F)
-  check_types <- sapply(
-    names(col_types),
-    function(nm) {
-      if (!is.na(types[nm])) {
-        col_types[[nm]] %in% TYPES_MAPPING[[types[nm]]]
-      } else
-        TRUE
-    }
-  )
+
+  schema_nm_check <- function(nm) {
+    if (nm %in% names(types)) {
+      col_types[[nm]] %in% TYPES_MAPPING[[types[[nm]]]]
+    } else
+      TRUE
+  }
+
+  check_types <- sapply(names(col_types), schema_nm_check)
   if (isFALSE(all(check_types)))
     stop(
       paste("Wrong types of columns:",


### PR DESCRIPTION
@mmc46 reported as follows. It seems that there was a change in the format of the clio schema

I’m getting an error when trying to add some annotations to manc_group  or manc_type.
Error in TYPES_MAPPING[[types[nm]]] : invalid subscript type 'list'
Details below for manc_group. The dataframe has only 2 columns, both integers.

```
manc_group_to_add <- structure(list(bodyid = c(805199L, 935352L, 806549L, 807065L, 
810834L, 804047L, 905422L, 803259L, 913338L, 810570L, 912337L, 
808516L, 811525L, 810465L, 811366L, 904174L, 905329L, 818561L, 
813817L, 820670L, 806289L, 810841L, 812885L, 802319L, 807847L, 
907783L, 811017L, 812310L, 814023L, 814504L, 912134L, 812425L, 
904397L, 811079L, 812986L, 814540L, 910376L, 810509L, 810792L, 
812515L, 813821L, 813880L, 821218L, 910802L, 1050632997L, 816200L, 
812150L, 814177L, 812585L, 814984L, 816521L, 816679L, 817494L, 
845417L, 911669L, 821195L, 821214L, 1050151038L, 1051333245L), 
    manc_group = c(14140L, 14567L, 14668L, 14668L, 14668L, 17368L, 
    17368L, 18555L, 18555L, 18729L, 19594L, 20066L, 20066L, 20417L, 
    20417L, 20417L, 20417L, 21101L, 21107L, 21107L, 21475L, 21475L, 
    21475L, 21785L, 21785L, 21785L, 21837L, 21837L, 21938L, 21938L, 
    21938L, 23094L, 23094L, 24764L, 24764L, 24764L, 24764L, 25779L, 
    25779L, 25779L, 25779L, 25779L, 25779L, 25779L, 25779L, 26044L, 
    27179L, 27179L, 28173L, 29350L, 29350L, 29350L, 29350L, 29350L, 
    30864L, 34059L, 34059L, 36453L, 36453L)), row.names = c(NA, 
-59L), class = c("tbl_df", "tbl", "data.frame"), dvid_node = "586443bc065849628f5bc180608f49c8")


mcns_annotate_body(x= data.frame(manc_group_to_add), protect = TRUE, test = FALSE)

Error in TYPES_MAPPING[[types[nm]]] : invalid subscript type 'list'
6.
col_types[[nm]] %in% TYPES_MAPPING[[types[nm]]]
5.
FUN(X[[i]], ...)
4.
lapply(X = X, FUN = FUN, ...)
3.
sapply(names(col_types), function(nm) {
if (!is.na(types[nm])) {
col_types[[nm]] %in% TYPES_MAPPING[[types[nm]]]
} ...
2.
schema_compare(x)
1.
mcns_annotate_body(x = data.frame(manc_group_to_add), protect = TRUE,
test = FALSE)
```